### PR TITLE
Add google play steps to the pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,8 @@ EXPO_PUBLIC_APPLE_TV_TOP_SHELF_WIDE_2X=<your_apple_tv_top_shelf_wide_2x_path>
   ```
 - **Code Signing for Apple & TestFlight:**
   Setting up code signing and TestFlight for Apple devices requires additional configuration. Refer to the [OwnTube Documentation](https://github.com/OwnTube-tv/web-client/blob/main/docs/pipeline.md) for detailed instructions on configuring code signing and deploying your app to TestFlight.
+- **Code Signing for Android & Google Play:**
+  Refer to the [OwnTube Documentation](https://github.com/OwnTube-tv/web-client/blob/main/docs/pipeline.md) for detailed instructions on how to configure delivery to Google Play.
 - Ensure all referenced files (e.g., icons and splash images) exist in the specified paths.
 - Double-check the configurations before deploying to avoid runtime errors.
 

--- a/build_branded_main.yml
+++ b/build_branded_main.yml
@@ -16,6 +16,21 @@ on:
         description: "Upload the tvOS build to Testflight"
         type: boolean
 
+      google_play_track:
+        description: "Upload the app to the following Google Play track:"
+        type: choice
+        required: false
+        options:
+          - none
+          - internal
+          - alpha
+          - beta
+          - production
+
+      google_play_upload_tv:
+        description: "Upload the Android TV build to selected Google Play track?"
+        type: boolean
+
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
@@ -127,6 +142,39 @@ jobs:
       build_info: ${{ needs.build_info.outputs.BUILD_INFO }}
       owntube_source: OwnTube-tv/web-client
       use_parent_repo_customizations: true
+
+  google_play_mobile:
+    needs: [build_info, customizations_setup]
+    uses: OwnTube-tv/web-client/.github/workflows/google_play.yml@main
+    if: ${{ github.event.inputs.google_play_track != 'none' }}
+    secrets:
+      KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+      SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+      RELEASE_KEYSTORE_CONTENT_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_CONTENT_BASE64 }}
+      SERVICE_ACCOUNT_JSON: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}
+    with:
+      customizations_env_content: ${{ needs.customizations_setup.outputs.CUSTOMIZATIONS_ENV_CONTENT }}
+      build_info: ${{ needs.build_info.outputs.BUILD_INFO }}
+      owntube_source: OwnTube-tv/web-client
+      track: ${{ github.event.inputs.google_play_track }}
+
+  google_play_tv:
+    needs: [build_info, customizations_setup]
+    uses: OwnTube-tv/web-client/.github/workflows/google_play.yml@main
+    if: ${{ github.event.inputs.google_play_track != 'none' && github.event.inputs.google_play_upload_tv == 'true' }}
+    secrets:
+      KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+      SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+      RELEASE_KEYSTORE_CONTENT_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_CONTENT_BASE64 }}
+      SERVICE_ACCOUNT_JSON: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}
+    with:
+      customizations_env_content: ${{ needs.customizations_setup.outputs.CUSTOMIZATIONS_ENV_CONTENT }}
+      build_info: ${{ needs.build_info.outputs.BUILD_INFO }}
+      owntube_source: OwnTube-tv/web-client
+      track: ${{ github.event.inputs.google_play_track }}
+      isTV: true
 
   testflight_ios:
     if: ${{ github.event.inputs.upload_ios_to_testflight == 'true' }}

--- a/google_play_initial_bundle.yml
+++ b/google_play_initial_bundle.yml
@@ -1,0 +1,41 @@
+name: Generate initial bundle(s) for manual upload to Google Play Console
+
+on:
+  workflow_dispatch:
+    inputs:
+      isTVNeeded:
+        description: "Bundle for Android TV as well?"
+        type: boolean
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "owntube-build"
+  cancel-in-progress: false
+
+jobs:
+  generate_android_bundle:
+    uses: OwnTube-tv/web-client/.github/workflows/google_play_initial_bundle.yml@main
+    secrets:
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+      ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+      ANDROID_RELEASE_KEYSTORE_CONTENT_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_CONTENT_BASE64 }}
+      ANDROID_SERVICE_ACCOUNT_JSON: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}
+    with:
+      owntube_source: OwnTube-tv/web-client
+      use_parent_repo_customizations: true
+
+  generate_android_tv_bundle:
+    if: ${{ github.event.inputs.isTVNeeded == 'true' }}
+    uses: OwnTube-tv/web-client/.github/workflows/google_play_initial_bundle.yml@main
+    secrets:
+      ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+      ANDROID_SIGNING_KEY_ALIAS: ${{ secrets.ANDROID_SIGNING_KEY_ALIAS }}
+      ANDROID_SIGNING_KEY_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEY_PASSWORD }}
+      ANDROID_RELEASE_KEYSTORE_CONTENT_BASE64: ${{ secrets.ANDROID_RELEASE_KEYSTORE_CONTENT_BASE64 }}
+      ANDROID_SERVICE_ACCOUNT_JSON: ${{ secrets.ANDROID_SERVICE_ACCOUNT_JSON }}
+    with:
+      isTV: true
+      owntube_source: OwnTube-tv/web-client
+      use_parent_repo_customizations: true


### PR DESCRIPTION
This PR extends the template to include steps to upload app builds to Google Play + generate .aab artifacts for the first always manual upload to Google Play Console.